### PR TITLE
Fixed spacing and inconsistent wording

### DIFF
--- a/Update/hima_002_03.txt
+++ b/Update/hima_002_03.txt
@@ -1065,7 +1065,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s05/13/101300285", 256, TRUE);
 	OutputLine(NULL, "「…遊びに行く？",
-		   NULL, "\"...Go and play?", Line_WaitForInput);
+		   NULL, "\"...Go play?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s05/13/101300286", 256, TRUE);
 	OutputLine(NULL, "　どんな店に遊びに行くんですか。」",
 		   NULL, " At what kind of place would you be doing that?\"", GetGlobalFlag(GLinemodeSp));

--- a/Update/hima_002_03_vm0x_n01.txt
+++ b/Update/hima_002_03_vm0x_n01.txt
@@ -65,7 +65,7 @@ void dialog005()
 		   NULL, " Loosen up a bit, we won't actually gamble anything.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 11, "ps3/s05/11/100700259", 256, TRUE);
 	OutputLine(NULL, "この後い〜いお店に遊びに行く時に、誰が全員分を払うのか決めるだけですって〜〜！",
-		   NULL, " We're just deciding whose going to pay for everyone at a very ni~ce place afterward~~!", Line_WaitForInput);
+		   NULL, " We're just deciding whose going to pay for everyone to go play at a very ni~ce place afterward~~!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 11, "ps3/s05/11/100700260", 256, TRUE);
 	OutputLine(NULL, "　むっふっふっふっふ〜〜！！！」",
 		   NULL, " Mfu fu fu fu fu~~!!!\"", GetGlobalFlag(GLinemodeSp));

--- a/Update/hima_003_03.txt
+++ b/Update/hima_003_03.txt
@@ -3631,7 +3631,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f5e6d3>誘拐犯</color>", NULL, "<color=#f5e6d3>Kidnapper</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 14, "ps3/s05/14/104700059", 256, TRUE);
 	OutputLine(NULL, "「警官が来る前に、お前ン額にもッパツくれちゃる方が早いんね。",
-		   NULL, "\"It'll be quicker ta put on thru yer 'ead afore the cops get 'ere.", Line_WaitForInput);
+		   NULL, "\"It'll be quicker ta put one thru yer 'ead afore the cops get 'ere.", Line_WaitForInput);
 	ModPlayVoiceLS(4, 14, "ps3/s05/14/104700060", 256, TRUE);
 	OutputLine(NULL, "無駄な殺生すなっちゅ、本家にゆわれとんかー加減しとんね。",
 		   NULL, " But tha family said no needless killin', so I'm taking it easy on ya.", Line_WaitForInput);

--- a/Update/hima_003_05.txt
+++ b/Update/hima_003_05.txt
@@ -1251,7 +1251,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#797d8a>赤坂</color>", NULL, "<color=#797d8a>Akasaka</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 13, "ps3/s05/13/101300658", 256, TRUE);
 	OutputLine(NULL, "「…梨花ちゃんが……？",
-		   NULL, "\"...You are?", Line_WaitForInput);
+		   NULL, "\"...You will?", Line_WaitForInput);
 	ModPlayVoiceLS(4, 13, "ps3/s05/13/101300659", 256, TRUE);
 	OutputLine(NULL, "　……どうして…、」",
 		   NULL, " ...Why?\"", GetGlobalFlag(GLinemodeSp));

--- a/Update/omake_04.txt
+++ b/Update/omake_04.txt
@@ -2358,7 +2358,7 @@ void main()
 
 	FadeOutBGM( 2, 1000, TRUE );
 
-	OutputLineAll(NULL, "", GetGlobalFlag(GLinemodeSp));
+	OutputLineAll(NULL, " ", GetGlobalFlag(GLinemodeSp));
 
 
 	PlayBGM( 2, "lsys24", 56, 0 );
@@ -2367,7 +2367,7 @@ void main()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f5e6d3>ナレーター</color>", NULL, "<color=#f5e6d3>Narrator</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 0, "ps3/s20/00/narra44008", 256, TRUE);
 	OutputLine(NULL, "永遠に等身大着せ替え人形の扱いをされてしまうのかッ？！？！",
-		   NULL, " being used as life-size dress-up dolls for all eternity!?!?", Line_Continue);
+		   NULL, "being used as life-size dress-up dolls for all eternity!?!?", Line_Continue);
 
 	FadeOutBGM( 2, 1000, TRUE );
 

--- a/Update/omake_04_vm00_n01.txt
+++ b/Update/omake_04_vm00_n01.txt
@@ -198,7 +198,7 @@ void dialog010()
 		   NULL, "\"This isn't some sort of transformation. I'll have you know I've always been a Demon Lord!!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100247", 256, TRUE);
 	OutputLine(NULL, "　そして今、真の闇に包まれたこの世界はまさに俺の手の平に等しい！！",
-		   NULL, " And as of right now, this world which is enveloped within true darkness shall dance upon the palm of my hand!!", GetGlobalFlag(GLinemodeSp));
+		   NULL, " And as of right now, this world which is enveloped within true darkness shall dance upon the palm of my hand!! ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100248", 256, TRUE);
 	OutputLine(NULL, "　この闇の世界では俺に逆らうことは何人にもかなわぬのだー！！！！」",
@@ -215,7 +215,7 @@ void dialog011()
 		   NULL, "\"Maebara-sama, you're the best~~!!!!!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 10, "ps3/s20/10/441000114", 256, TRUE);
 	OutputLine(NULL, "　その後はバニーさんにバドガールに、いえいえ、ランジェリー姿もいいですねぇ！！",
-		   NULL, " How about a bunny girl, or campaign girl costu-- no no, lingerie could be good too!!", GetGlobalFlag(GLinemodeSp));
+		   NULL, " How about a bunny girl, or campaign girl costu-- no no, lingerie could be good too!! ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#c89a80>入江</color>", NULL, "<color=#c89a80>Irie</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 10, "ps3/s20/10/441000115", 256, TRUE);
 	OutputLine(NULL, "　いやいや！！",
@@ -232,7 +232,7 @@ void dialog011()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#c89a80>入江</color>", NULL, "<color=#c89a80>Irie</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 10, "ps3/s20/10/441000117", 256, TRUE);
 	OutputLine(NULL, "　も、もちろん、靴下は残すのでありまっす！！！」",
-		   NULL, " B-But of course, leave the socks on!!!\"", Line_Normal);
+		   NULL, "B-But of course, leave the socks on!!!\"", Line_Normal);
 	ClearMessage();
 }
 
@@ -298,7 +298,7 @@ void dialog015()
 //　お疲れ様会の度に＠　立ち絵がなく、慰労の一杯にすらありつけなかった俺の!w800/
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100243", 256, TRUE);
 	OutputLine(NULL, "　お疲れ様会の度に！",
-		   NULL, " Every. Afterparty.", GetGlobalFlag(GLinemodeSp));
+		   NULL, " Every. Afterparty. ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100244", 256, TRUE);
 	OutputLine(NULL, "　立ち絵がなく、慰労の一杯にすらありつけなかった俺の",
@@ -341,7 +341,7 @@ void dialog015()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100245", 256, TRUE);
 	OutputLine(NULL, "　今こそ教えてくれるぜえええぇえぇ！！！」",
-		   NULL, " I shall instill it all upon you!!!\"", Line_Continue);
+		   NULL, "I shall instill it all upon you!!!\"", Line_Continue);
 }
 
 
@@ -395,7 +395,7 @@ void dialog016()
 		   NULL, " Wa-wait, you can't use that big one!!!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100283", 256, TRUE);
 	OutputLine(NULL, "　えぇえ？！",
-		   NULL, " Huuuh!?", GetGlobalFlag(GLinemodeSp));
+		   NULL, " Huuuh!? ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100284", 256, TRUE);
 	OutputLine(NULL, "　ゲージ技って、出掛かり無敵かよッ？！",

--- a/Update/omake_04_vm0x_n01.txt
+++ b/Update/omake_04_vm0x_n01.txt
@@ -187,7 +187,7 @@ void dialog005()
 		   NULL, "\"Let's see... Kei-chan has about 500,", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300450", 256, TRUE);
 	OutputLine(NULL, "詩音は…………２７００越えぇぇっ？！",
-		   NULL, "\" and Shion has... over 2700?!", Line_WaitForInput);
+		   NULL, " and Shion has... over 2700?!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 3, "ps3/s20/03/440300451", 256, TRUE);
 	OutputLine(NULL, "　これ、普通のアドベンチャーゲームなら全キャラの総合計数だよっ！！」",
 		 NULL, " That's like the total for all the characters together in a normal adventure game!!\"", Line_Normal);
@@ -296,7 +296,7 @@ void dialog010()
 		   NULL, "\"This isn't some sort of transformation. I'll have you know I've always been a Demon Lord!!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100247", 256, TRUE);
 	OutputLine(NULL, "　そして、俺が抑圧された悪夢の中で手に入れた闇の力は、まさに無限大で無量大数！！",
-		   NULL, " And the dark power I obtained during my suppressed nightmare truly knows no bounds!!", GetGlobalFlag(GLinemodeSp));
+		   NULL, " And the dark power I obtained during my suppressed nightmare truly knows no bounds!! ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100248", 256, TRUE);
 	OutputLine(NULL, "　俺の俺による俺のために作り出したこの闇の世界では、俺に逆らうことは何人にもかなわぬのだー！！！！」",
@@ -313,7 +313,7 @@ void dialog011()
 		   NULL, "\"Maebara-sama, you're the best~~!!!!!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 10, "ps3/s20/10/441000114", 256, TRUE);
 	OutputLine(NULL, "　その後はバニーさんにコンパニオンに、いえいえ、レオタード姿もいいですねぇ！！",
-		   NULL, " How about a bunny girl, or booth babe costu-- no no, a leotard could be good too!!", GetGlobalFlag(GLinemodeSp));
+		   NULL, " How about a bunny girl, or booth babe costu-- no no, a leotard could be good too!! ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#c89a80>入江</color>", NULL, "<color=#c89a80>Irie</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 10, "ps3/s20/10/441000115", 256, TRUE);
 	OutputLine(NULL, "　いやいや！！",
@@ -330,7 +330,7 @@ void dialog011()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#c89a80>入江</color>", NULL, "<color=#c89a80>Irie</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 10, "ps3/s20/10/441000117", 256, TRUE);
 	OutputLine(NULL, "　も、もちろん、靴下は残すのでありまっす！！！」",
-		   NULL, " B-But of course, leave the socks on!!!\"", Line_Normal);
+		   NULL, "B-But of course, leave the socks on!!!\"", Line_Normal);
 	ClearMessage();
 }
 
@@ -396,7 +396,7 @@ void dialog015()
 //　お疲れ様会の度に＠　立ち絵がなく、慰労の一杯にすらありつけなかった俺の!w800/
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100243", 256, TRUE);
 	OutputLine(NULL, "　お疲れ様会の度に！",
-		   NULL, " Every. Afterparty.", GetGlobalFlag(GLinemodeSp));
+		   NULL, " Every. Afterparty. ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100244", 256, TRUE);
 	OutputLine(NULL, "　常に居残りになって、慰労の一杯にすらありつけなかった俺の",
@@ -439,7 +439,7 @@ void dialog015()
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100245", 256, TRUE);
 	OutputLine(NULL, "　今こそ教えてくれるぜえええぇえぇ！！！」",
-		   NULL, " I shall instill it all upon you!!!\"", Line_Continue);
+		   NULL, "I shall instill it all upon you!!!\"", Line_Continue);
 }
 
 
@@ -493,7 +493,7 @@ void dialog016()
 		   NULL, " Wa-wait, you can't use that big one!!!", Line_WaitForInput);
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100283", 256, TRUE);
 	OutputLine(NULL, "　えぇえ？！",
-		   NULL, " Huuuh!?", GetGlobalFlag(GLinemodeSp));
+		   NULL, " Huuuh!? ", GetGlobalFlag(GLinemodeSp));
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#956f6e>圭一</color>", NULL, "<color=#956f6e>Keiichi</color>", NULL, Line_ContinueAfterTyping); }
 	ModPlayVoiceLS(4, 1, "ps3/s20/01/440100284", 256, TRUE);
 	OutputLine(NULL, "　は、早すぎるッ？！",


### PR DESCRIPTION
A number of spacing issues and other wording fixes. Specifically:

1.  hima_002_03 had some inconsistent wording, where Asakasa replies "Go and play?" to a line that, depending on PC or console, either includes "go play" with no "and" or doesn't mention playing at all. 
PC: 
 "誰が払ったにせよ、そのお金でこの後はい〜いお店に遊びに行くのに使いますよ〜〜！"
"But it doesn't matter who loses, because after this, we're using that money to go play at a very ni~ce place~~!"
Console: 
"この後い〜いお店に遊びに行く時に、誰が全員分を払うのか決めるだけですって〜〜！"
"We're just deciding whose going to pay for everyone at a very ni~ce place afterward~~!"

From what I can tell (disclaimer: that's checking the machine translation of both and also confirming the voiced line is still "…遊びに行く？"), the reference to playing being removed is just from the translation and wasn't removed from the console line. So I've changed his response to "Go play?" and included it in the console line ("pay for everyone to go play at") as well.

2. hima_003_03 seemingly had a typo: "It'll be quicker ta put **on** thru yer 'ead afore the cops get 'ere." Changed that to "one". This _might_ have been intentional due to their accent, but it doesn't read clearly in the way the rest of the line does, and given that "put on" was used normally just a few lines before I'm thinking it's a typo that was missed due to that.

3. hima_003_05 had "You are?" as the response to "I'll be killed.", which doesn't make sense. So I've changed it to "You will?".

4. Cast review session had a lot of spacing issues. I'm a NVL player but while fixing it I noticed that there were some ADV-specific issues too, so I've done my best to fix them in a way that works for both. It feels attempting to support both modes is probably why this happened to begin with, so hopefully I caught most of it.